### PR TITLE
CLN CI config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,5 +40,5 @@ jobs:
       run: |
         eval "$(conda shell.bash hook)"
         conda activate base
-        benchopt test . --env-name benchopt_ols_test_env -vl
-        benchopt test . --env-name benchopt_ols_test_env -vl --skip-install
+        benchopt test . --env-name bench_test_env -vl
+        benchopt test . --env-name bench_test_env -vl --skip-install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         conda activate base
         # make sure we have the latest version of pip to correctly install benchopt in sub conda env
         pip install --upgrade pip
-        pip install -U https://api.github.com/repos/benchopt/benchOpt/zipball/CLN_remove_benchmarks
+        pip install -U https://api.github.com/repos/benchopt/benchOpt/zipball/master
     - name: Lint with flake8
       run: |
         pip install flake8


### PR DESCRIPTION
Use master branch and have a config file independent of the benchmark name so we can easily copy it in other repo.